### PR TITLE
feat: Add prebuild mechanics for native bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /build
+/prebuilds

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.*
+/scripts
+/test
+/prebuilds

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,10 @@ addons:
     packages:
       - bc
       - g++-4.8
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: scripts/prebuild-publish.sh
+  on:
+    tags: true
+    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+# appveyor file
+# http://www.appveyor.com/docs/appveyor-yml
+image:
+  - Visual Studio 2015
+
+init:
+  - git config --global core.autocrlf input
+
+cache:
+  - C:\Users\appveyor\.node-gyp
+  - '%AppData%\npm-cache'
+
+environment:
+  matrix:
+    - nodejs_version: 8
+
+install:
+  - ps: Install-Product node $env:nodejs_version x64
+  - set PATH=C:\MinGW\bin;%PATH%
+  - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install --build-from-source
+
+build: off
+
+test_script:
+  - node --version
+  - npm --version
+  - cmd: npm test
+
+deploy_script:
+  - scripts\prebuild-publish.bat

--- a/package.json
+++ b/package.json
@@ -16,11 +16,14 @@
     "pretest": "eslint lib test",
     "test": "mocha",
     "publish-please": "publish-please",
-    "prepublish": "publish-please guard"
+    "prepublish": "publish-please guard",
+    "install": "prebuild-install || node-gyp rebuild",
+    "prebuild": "prebuild --all --strip"
   },
   "devDependencies": {
     "eslint": "^3.19.0",
     "mocha": "^2.2.5",
+    "prebuild": "^6.2.2",
     "publish-please": "^2.2.0"
   },
   "dependencies": {
@@ -28,6 +31,7 @@
     "bindings": "^1.2.1",
     "bluebird": "3.5.0",
     "file-disk": "0.0.10",
-    "nan": "^2.5.1"
+    "nan": "^2.5.1",
+    "prebuild-install": "^2.3.0"
   }
 }

--- a/scripts/prebuild-publish.bat
+++ b/scripts/prebuild-publish.bat
@@ -1,0 +1,7 @@
+@echo off
+
+if %APPVEYOR_REPO_BRANCH% == master (
+  if %GITHUB_TOKEN% neq "" (
+    npm run prebuild -- -u %GITHUB_TOKEN%
+  )
+)

--- a/scripts/prebuild-publish.sh
+++ b/scripts/prebuild-publish.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [[ $GITHUB_TOKEN ]]; then
+  npm run prebuild -- -u "$GITHUB_TOKEN"
+fi


### PR DESCRIPTION
This adds the ability to automatically generate & publish
prebuilt binaries of the native bindings for all platforms and runtime versions.

To generate prebuilds locally, just run `npm run prebuild`, and to also publish them `npm run prebuild --  -u "$GITHUB_TOKEN"` where the `$GITHUB_TOKEN` needs to be an access token. This access token would also have to be provided to the CI services in order for them to automatically publish the prebuilds.

~~NOTE: For automatic prebuilds to be generated for Windows, AppVeyor would need to be enabled as a CI as well (the `appveyor.yml` is added in this PR already).~~

Change-Type: minor
Connects To: #37 